### PR TITLE
fix: pass sandbox mode to Codex on session resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ SEREN_ACP_CODEX_SANDBOX=danger-full-access cargo run --release --bin seren-acp-c
 - `prompt`
 - `setSessionMode`
 - `cancel`
-- `loadSession` is not supported
+- `loadSession` (resumes an existing Codex thread by ID)
 
 **High-level event mapping**
 - ACP session = Codex thread

--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -1593,6 +1593,7 @@ impl acp::Agent for CodexAgent {
             .thread_resume(crate::codex::ThreadResumeParams {
                 thread_id: thread_id.clone(),
                 cwd: Some(cwd.clone()),
+                sandbox: Some(Self::sandbox_mode_from_env()),
                 ..Default::default()
             })
             .await


### PR DESCRIPTION
## Summary

- load_session called thread_resume with sandbox: None, causing Codex to revert to its default workspace-write sandbox on resumed sessions
- Shell subprocesses under workspace-write have Codex internal seatbelt applied, which blocks DNS (curl: (6) Could not resolve host)
- new_session correctly passes sandbox from SEREN_ACP_CODEX_SANDBOX; resume path now does the same
- Also fixed README: loadSession was incorrectly listed as unsupported

## Test plan

- Start a Codex session with SEREN_ACP_CODEX_SANDBOX=danger-full-access, run curl — DNS resolves
- Resume the same session, run curl — DNS still resolves (was broken before)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com