### PR TITLE
fix: use CODEX_CLI_PATH env var to locate codex binary

### DIFF
--- a/src/codex/client.rs
+++ b/src/codex/client.rs
@@ -45,7 +45,10 @@ impl CodexClient {
     pub async fn connect(_url: &str, mcp_servers: Option<Vec<McpServerConfig>>) -> Result<Self> {
         info!("Spawning Codex app-server process");
 
-        let mut cmd = Command::new("codex");
+        // Use CODEX_CLI_PATH if set (provided by seren-desktop), otherwise fall back to PATH.
+        let codex_bin = std::env::var("CODEX_CLI_PATH").unwrap_or_else(|_| "codex".to_string());
+        info!("Using codex binary: {}", codex_bin);
+        let mut cmd = Command::new(&codex_bin);
         cmd.arg("app-server");
 
         // Add MCP server configurations as -c arguments


### PR DESCRIPTION
## Summary
- Check CODEX_CLI_PATH env var before falling back to Command::new("codex") for PATH resolution
- On Windows, Rust does not resolve .cmd files via PATHEXT, so Command::new("codex") fails to find codex.cmd

## Companion PR
serenorg/seren-desktop#876 sets CODEX_CLI_PATH for Codex agent sessions (instead of incorrectly setting CLAUDE_CLI_PATH).

## Test plan
- [ ] Verify Codex agent starts on Windows with CODEX_CLI_PATH set
- [ ] Verify Codex agent still works on macOS/Linux without CODEX_CLI_PATH (falls back to PATH)

Closes serenorg/seren#143

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com