### PR TITLE
fix: isolate Codex process group on Windows to prevent Ctrl+C kill (#6)

### DIFF
--- a/src/codex/client.rs
+++ b/src/codex/client.rs
@@ -61,6 +61,16 @@ impl CodexClient {
             }
         }
 
+        // On Windows, isolate the child from the parent's console process group so that
+        // Ctrl+C signals sent to the Tauri window don't propagate and kill the sidecar
+        // (exit code 0xc000013a / STATUS_CONTROL_C_EXIT).
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        }
+
         let mut child = cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
- Add `CREATE_NEW_PROCESS_GROUP` (0x200) creation flag when spawning Codex app-server on Windows
- Prevents Ctrl+C signals from propagating from Tauri parent to sidecar child process
- Root cause of exit code 0xc000013a (STATUS_CONTROL_C_EXIT) on Windows

## Test plan
- [ ] On Windows: verify Codex sessions survive Ctrl+C / console close of parent window
- [ ] `cargo check` passes

Fixes #6

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
